### PR TITLE
fix(blog): apply data-theme on toggle for instant theme switch

### DIFF
--- a/static/js/app.js
+++ b/static/js/app.js
@@ -30,6 +30,7 @@
   function applyTheme(theme) {
     const effective = getEffectiveTheme(theme);
     document.documentElement.setAttribute('data-user-color-scheme', effective);
+    document.documentElement.setAttribute('data-theme', effective);
     document.documentElement.setAttribute('data-theme-setting', theme);
 
     // Dispatch event for other components


### PR DESCRIPTION
In `blog`/`site` mode, clicking the theme toggle only changes some text colors — the page background does not update until a full reload.

```diff
 function applyTheme(theme) {
   const effective = getEffectiveTheme(theme);
   document.documentElement.setAttribute('data-user-color-scheme', effective);
+  document.documentElement.setAttribute('data-theme', effective);
   document.documentElement.setAttribute('data-theme-setting', theme);
   ...
 }
```

This matches the inline script's behavior and the docs/book/product mode toggle
(`theme.js`), so background and palette colors update immediately on click.